### PR TITLE
Update golint URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ENV GOPATH /go
 ENV PATH /go/bin:$PATH
 
 # gotools
-RUN go get -u github.com/golang/lint/golint
+RUN go get -u golang.org/x/lint/golint
 RUN go get -u honnef.co/go/tools/cmd/gosimple
 RUN go get -u honnef.co/go/tools/cmd/unused
 RUN go get -u mvdan.cc/unparam

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 init_gotools:
-	go get -u github.com/golang/lint/golint
+	go get -u golang.org/x/lint/golint
 	go get -u honnef.co/go/tools/cmd/gosimple
 	go get -u honnef.co/go/tools/cmd/unused
 	go get -u mvdan.cc/unparam

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Pronto runner for [Golang](https://golang.org) tools
 
 |  Tool    | Install  |
 |----------|----------|
-| golint   | go get -u github.com/golang/lint/golint |
+| golint   | golang.org/x/lint/golint |
 | gosimple | go get -u honnef.co/go/tools/cmd/gosimple |
 | go vet   | - |
 | unused   | go get -u honnef.co/go/tools/cmd/unused |


### PR DESCRIPTION
Should solve

```
Step 9/18 : RUN go get -u github.com/golang/lint/golint
 ---> Running in ee849529ae19
package github.com/golang/lint/golint: code in directory /go/src/github.com/golang/lint/golint expects import "golang.org/x/lint/golint"
The command '/bin/sh -c go get -u github.com/golang/lint/golint' returned a non-zero code: 1
```