### PR TITLE
Fix/path reporting

### DIFF
--- a/lib/pronto/golang.rb
+++ b/lib/pronto/golang.rb
@@ -57,7 +57,7 @@ module Pronto
 
       patch.added_lines.each do |line|
         if line_number.to_s == line.new_lineno.to_s &&
-           patch.new_file_full_path.to_s == file_path
+           patch.new_file_full_path.to_s == File.expand_path(file_path)
 
           return Message.new(
             file_path, line, severity, message, line.commit_sha, self.class

--- a/lib/pronto/golang/tools/errcheck.rb
+++ b/lib/pronto/golang/tools/errcheck.rb
@@ -16,7 +16,7 @@ module Pronto
       def parse_line(line)
         file_path, line_number, _, _ = line.split(':')
 
-        return File.expand_path(file_path), line_number, :warning, message
+        [file_path, line_number, :warning, message]
       end
 
       def message

--- a/lib/pronto/golang/tools/golint.rb
+++ b/lib/pronto/golang/tools/golint.rb
@@ -16,7 +16,7 @@ module Pronto
       def parse_line(line)
         file_path, line_number, _, message = line.split(':')
 
-        return File.expand_path(file_path), line_number, :warning, message.strip
+        [file_path, line_number, :warning, message.strip]
       end
     end
   end

--- a/lib/pronto/golang/tools/gosimple.rb
+++ b/lib/pronto/golang/tools/gosimple.rb
@@ -16,7 +16,7 @@ module Pronto
       def parse_line(line)
         file_path, line_number, _, message = line.split(':')
 
-        return File.expand_path(file_path), line_number, :warning, message.strip
+        [file_path, line_number, :warning, message.strip]
       end
     end
   end

--- a/lib/pronto/golang/tools/govet.rb
+++ b/lib/pronto/golang/tools/govet.rb
@@ -16,7 +16,7 @@ module Pronto
       def parse_line(line)
         file_path, line_number, message = line.split(':')
 
-        return File.expand_path(file_path), line_number, :warning, message.strip
+        [file_path, line_number, :warning, message.strip]
       end
     end
   end

--- a/lib/pronto/golang/tools/unparam.rb
+++ b/lib/pronto/golang/tools/unparam.rb
@@ -16,7 +16,7 @@ module Pronto
       def parse_line(line)
         file_path, line_number, _, message = line.split(':')
 
-        return File.expand_path(file_path), line_number, :warning, message.strip
+        [file_path, line_number, :warning, message.strip]
       end
     end
   end

--- a/lib/pronto/golang/tools/unused.rb
+++ b/lib/pronto/golang/tools/unused.rb
@@ -16,7 +16,7 @@ module Pronto
       def parse_line(line)
         file_path, line_number, _, message = line.split(':')
 
-        return File.expand_path(file_path), line_number, :warning, message.strip
+        [file_path, line_number, :warning, message.strip]
       end
     end
   end

--- a/lib/pronto/golang/version.rb
+++ b/lib/pronto/golang/version.rb
@@ -1,5 +1,5 @@
 module Pronto
   module GolangVersion
-    VERSION = '0.0.3'.freeze
+    VERSION = '0.0.4'.freeze
   end
 end


### PR DESCRIPTION
Output before:
```
% pronto run
/home/benner/go/src/foo/bar/main.go:10 W: var serviceUrl should be serviceURL
a.rb:1 W: Style/FrozenStringLiteralComment: Missing magic comment `# frozen_string_literal: true`.
a.rb:1 W: Layout/SpaceAroundOperators: Surrounding space missing for operator `=`.
test.yml:9 E: 9:81: [error] line too long (94 > 80 characters) (line-length)
test.yml:10 E: 10:81: [error] line too long (95 > 80 characters) (line-length)
```

Expected output:
```
% pronto run 
main.go:10 W: var serviceUrl should be serviceURL
a.rb:1 W: Style/FrozenStringLiteralComment: Missing magic comment `# frozen_string_literal: true`.
a.rb:1 W: Layout/SpaceAroundOperators: Surrounding space missing for operator `=`.
test.yml:9 E: 9:81: [error] line too long (94 > 80 characters) (line-length)
test.yml:10 E: 10:81: [error] line too long (95 > 80 characters) (line-length)
```